### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "ms-conf": "^2.3.0",
     "ms-validation": "^3.0.0",
     "mservice": "^4.6.0",
-    "node-uuid": "^1.4.7",
     "pg": "^6.1.0",
     "pg-native": "^1.10.0",
     "rrule": "^2.1.0",
-    "uid2": "0.0.3"
+    "uid2": "0.0.3",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "apidoc": "^0.16.1",

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -2,7 +2,7 @@ const is = require('is');
 const LightUserModel = require('../models/lightUserModel');
 const Promise = require('bluebird');
 const uid2 = require('uid2');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 const { ROLE_GUEST } = LightUserModel;
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.